### PR TITLE
fix the flickering

### DIFF
--- a/TowerDefense/TowerDefense/Enemy.cs
+++ b/TowerDefense/TowerDefense/Enemy.cs
@@ -62,8 +62,8 @@ namespace TowerDefense
         }
         public void initPosition(Tile startTile)
         {
-            pos_x = GridParams.StartX + ((double)startTile.x) * GridParams.TileSize;
-            pos_y = GridParams.StartY + ((double)startTile.y) * GridParams.TileSize;
+            pos_x = ((double)startTile.x) * GridParams.TileSize;
+            pos_y = ((double)startTile.y) * GridParams.TileSize;
         }
         public abstract void move(double delta_t); //calculate movement
         public abstract void statusEffect(double delta_t); //calculate status effects

--- a/TowerDefense/TowerDefense/GameForm.Designer.cs
+++ b/TowerDefense/TowerDefense/GameForm.Designer.cs
@@ -28,7 +28,6 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(GameForm));
             this.start_menu_panel = new System.Windows.Forms.Panel();
             this.help_panel = new System.Windows.Forms.Panel();
@@ -40,7 +39,6 @@
             this.select_level_button = new System.Windows.Forms.Button();
             this.help_button = new System.Windows.Forms.Button();
             this.exit_button = new System.Windows.Forms.Button();
-            this.timer1 = new System.Windows.Forms.Timer(this.components);
             this.start_menu_panel.SuspendLayout();
             this.help_panel.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.cover_pictureBox)).BeginInit();
@@ -176,10 +174,6 @@
             this.exit_button.UseVisualStyleBackColor = false;
             this.exit_button.Click += new System.EventHandler(this.exit_button_Click);
             // 
-            // timer1
-            // 
-            this.timer1.Tick += new System.EventHandler(this.timer1_Tick);
-            // 
             // GameForm
             // 
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
@@ -208,7 +202,6 @@
         private System.Windows.Forms.TextBox help_content_textBox;
         private System.Windows.Forms.Button help_to_start_menu_button;
         private System.Windows.Forms.Panel game_scene_panel;
-        private System.Windows.Forms.Timer timer1;
     }
 }
 

--- a/TowerDefense/TowerDefense/GameForm.cs
+++ b/TowerDefense/TowerDefense/GameForm.cs
@@ -40,13 +40,6 @@ namespace TowerDefense
             help_panel.Controls.Add(help_content_textBox);
         }
 
-        private void timer1_Tick(object sender, EventArgs e)
-        {
-            if (game_scene_panel.Visible)
-            {
-                game_scene_panel.Invalidate();
-            }
-        }
         private void pictureBox1_Click(object sender, EventArgs e)
         {
 
@@ -62,7 +55,7 @@ namespace TowerDefense
             game = new Game("chapter1/1-1.txt");
             level = game.Level;
 
-            timer1.Start();
+            //timer1.Start();
 
             Thread thread = new Thread(() => { game.waveRun(this); });
             thread.Start();
@@ -88,7 +81,6 @@ namespace TowerDefense
 
         private void textBox3_TextChanged(object sender, EventArgs e)
         {
-           
 
         }
 
@@ -156,12 +148,12 @@ namespace TowerDefense
             // 将场景图片绘制到屏幕上
             Graphics g = e.Graphics;
             g.DrawImage(gameSceneImage, GridParams.StartX, GridParams.StartY, GridParams.GridSizeX * GridParams.TileSize, GridParams.GridSizeY * GridParams.TileSize);
+
+            this.Invalidate();
         }
 
         public void waveCallback(int val)
         {
-            timer1.Stop();
-
             //callback: 0:failed, 1:wave success, 2:level complete
             throw new NotImplementedException();
             //TODO

--- a/TowerDefense/TowerDefense/GameForm.resx
+++ b/TowerDefense/TowerDefense/GameForm.resx
@@ -121,7 +121,7 @@
   <data name="cover_pictureBox.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAABJ0AAANRCAYAAABJPc0GAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        vgAADr4B6kKxwAAA/7JJREFUeF7s/eeTJNeZ53v2P7HKbHfv7t65c2fumq2tuGu772bG9vaI7p7WnJbT
+        vQAADr0BR/uQrQAA/7JJREFUeF7s/eeTJNeZ53v2P7HKbHfv7t65c2fumq2tuGu772bG9vaI7p7WnJbT
         Yropms0WbLZgU4OEIChACJIACEKVQFWhCqV1yhJZuip1hhaptdby2fM7Ho/H4yce9/CIzCwUSLz4WmgP
         D4+ILPgHx0/8wv/6X/0y/fKX2ujffv227f/3tdv0v3z9TkX/wdz2H5+6a/tP37wX6Je+dZ/+89P36Fef
         uU+/9uwDv994ptxvPvvI9lvPtdMnnu+g33m+0/a73+my/cF3u+kPv9dLf/T9Htsfv9Dr9ycv9tj+9KVe
@@ -24750,9 +24750,6 @@
         gg==
 </value>
   </data>
-  <metadata name="timer1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>227, 17</value>
-  </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>25</value>
   </metadata>


### PR DESCRIPTION
# 新增
1. 将绘制调整会绘制函数结束后调用重绘消息，防止因为计时器过快导致下一帧的绘制覆盖上一帧导致的闪烁

# 修改
1. 将enemy pos修改为相对于grid左上角的位置

# 需求
1. 游戏运行时似乎list<enemy>长度始终为0